### PR TITLE
Threadpool and Abort

### DIFF
--- a/ecdsa/party/implementation.go
+++ b/ecdsa/party/implementation.go
@@ -196,12 +196,15 @@ func (p *Impl) Start(outChannel chan tss.Message, signatureOutputChannel chan *c
 	}
 
 	p.parameters.Context = p.ctx
-	p.parameters.AsyncWorkComputation = func(f func()) {
+	p.parameters.AsyncWorkComputation = func(f func()) error {
 		select {
 		case p.cryptoWorkChan <- f:
+			return nil
 		case <-p.ctx.Done():
+			return errors.New("context aborted")
 		}
 	}
+
 	for i := 0; i < runtime.NumCPU(); i++ {
 		go p.cryptoWorker()
 	}

--- a/ecdsa/signing/round_1.go
+++ b/ecdsa/signing/round_1.go
@@ -74,14 +74,16 @@ func (round *round1) Start() *tss.Error {
 		}
 		r1msg1 := NewSignRound1Message1(Pj, round.PartyID(), cA, pi, round.temp.m)
 		round.temp.cis[j] = cA
-		round.out <- r1msg1
+
+		if err := round.sendMessage(r1msg1); err != nil {
+			return err
+		}
 	}
 
 	r1msg2 := NewSignRound1Message2(round.PartyID(), cmt.C, round.temp.m)
 	round.temp.signRound1Message2s[i] = r1msg2
-	round.out <- r1msg2
 
-	return nil
+	return round.sendMessage(r1msg2)
 }
 
 func (round *round1) Update() (bool, *tss.Error) {

--- a/ecdsa/signing/round_2.go
+++ b/ecdsa/signing/round_2.go
@@ -119,7 +119,10 @@ func (round *round2) Start() *tss.Error {
 		r2msg := NewSignRound2Message(
 			Pj, round.PartyID(), round.temp.c1jis[j], round.temp.pi1jis[j], round.temp.c2jis[j], round.temp.pi2jis[j],
 			round.temp.m)
-		round.out <- r2msg
+
+		if err := round.sendMessage(r2msg); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/ecdsa/signing/round_3.go
+++ b/ecdsa/signing/round_3.go
@@ -119,9 +119,8 @@ func (round *round3) Start() *tss.Error {
 	round.temp.sigma = sigma
 	r3msg := NewSignRound3Message(round.PartyID(), thelta, round.temp.m)
 	round.temp.signRound3Messages[round.PartyID().Index] = r3msg
-	round.out <- r3msg
 
-	return nil
+	return round.sendMessage(r3msg)
 }
 
 func (round *round3) Update() (bool, *tss.Error) {

--- a/ecdsa/signing/round_4.go
+++ b/ecdsa/signing/round_4.go
@@ -50,9 +50,8 @@ func (round *round4) Start() *tss.Error {
 	round.temp.thetaInverse = thetaInverse
 	r4msg := NewSignRound4Message(round.PartyID(), round.temp.deCommit, piGamma, round.temp.m)
 	round.temp.signRound4Messages[round.PartyID().Index] = r4msg
-	round.out <- r4msg
 
-	return nil
+	return round.sendMessage(r4msg)
 }
 
 func (round *round4) Update() (bool, *tss.Error) {

--- a/ecdsa/signing/round_5.go
+++ b/ecdsa/signing/round_5.go
@@ -82,7 +82,10 @@ func (round *round5) Start() *tss.Error {
 	cmt := commitments.NewHashCommitment(round.Rand(), bigVi.X(), bigVi.Y(), bigAi.X(), bigAi.Y())
 	r5msg := NewSignRound5Message(round.PartyID(), cmt.C, round.temp.m)
 	round.temp.signRound5Messages[round.PartyID().Index] = r5msg
-	round.out <- r5msg
+
+	if err := round.sendMessage(r5msg); err != nil {
+		return err
+	}
 
 	round.temp.li = li
 	round.temp.bigAi = bigAi

--- a/ecdsa/signing/round_6.go
+++ b/ecdsa/signing/round_6.go
@@ -37,8 +37,8 @@ func (round *round6) Start() *tss.Error {
 
 	r6msg := NewSignRound6Message(round.PartyID(), round.temp.DPower, piAi, piV, round.temp.m)
 	round.temp.signRound6Messages[round.PartyID().Index] = r6msg
-	round.out <- r6msg
-	return nil
+
+	return round.sendMessage(r6msg)
 }
 
 func (round *round6) Update() (bool, *tss.Error) {

--- a/ecdsa/signing/round_7.go
+++ b/ecdsa/signing/round_7.go
@@ -86,7 +86,9 @@ func (round *round7) Start() *tss.Error {
 	cmt := commitments.NewHashCommitment(round.Rand(), UiX, UiY, TiX, TiY)
 	r7msg := NewSignRound7Message(round.PartyID(), cmt.C, round.temp.m)
 	round.temp.signRound7Messages[round.PartyID().Index] = r7msg
-	round.out <- r7msg
+	if err := round.sendMessage(r7msg); err != nil {
+		return err
+	}
 	round.temp.DTelda = cmt.D
 
 	return nil

--- a/ecdsa/signing/round_8.go
+++ b/ecdsa/signing/round_8.go
@@ -22,9 +22,8 @@ func (round *round8) Start() *tss.Error {
 
 	r8msg := NewSignRound8Message(round.PartyID(), round.temp.DTelda, round.temp.m)
 	round.temp.signRound8Messages[round.PartyID().Index] = r8msg
-	round.out <- r8msg
 
-	return nil
+	return round.sendMessage(r8msg)
 }
 
 func (round *round8) Update() (bool, *tss.Error) {

--- a/ecdsa/signing/round_9.go
+++ b/ecdsa/signing/round_9.go
@@ -46,8 +46,8 @@ func (round *round9) Start() *tss.Error {
 
 	r9msg := NewSignRound9Message(round.PartyID(), round.temp.si, round.temp.m)
 	round.temp.signRound9Messages[round.PartyID().Index] = r9msg
-	round.out <- r9msg
-	return nil
+
+	return round.sendMessage(r9msg)
 }
 
 func (round *round9) Update() (bool, *tss.Error) {

--- a/ecdsa/signing/rounds.go
+++ b/ecdsa/signing/rounds.go
@@ -147,12 +147,18 @@ func (round *base) sendMessage(msg tss.ParsedMessage) *tss.Error {
 	}
 }
 
-func (round *base) asyncRunTask(f func()) {
+// Attempts to run task asynchronly. if Params has a defined task-runner, will return whether it was successful or not.
+func (round *base) runAsyncTask(f func()) *tss.Error {
 	if round.Params() == nil || round.Params().AsyncWorkComputation == nil {
 		go f()
+		return nil
 	}
 
-	round.Params().AsyncWorkComputation(f)
+	if err := round.Params().AsyncWorkComputation(f); err != nil {
+		return round.WrapError(err)
+	}
+
+	return nil
 }
 
 // get ssid from local params

--- a/tss/params.go
+++ b/tss/params.go
@@ -7,6 +7,7 @@
 package tss
 
 import (
+	"context"
 	"crypto/elliptic"
 	"crypto/rand"
 	"io"
@@ -30,6 +31,10 @@ type (
 		noProofFac bool
 		// random sources
 		partialKeyRand, rand io.Reader
+
+		// can be used by rounds to perform work asynchronously
+		Context              context.Context
+		AsyncWorkComputation func(func())
 	}
 
 	ReSharingParameters struct {
@@ -56,6 +61,10 @@ func NewParameters(ec elliptic.Curve, ctx *PeerContext, partyID *PartyID, partyC
 		safePrimeGenTimeout: defaultSafePrimeGenTimeout,
 		partialKeyRand:      rand.Reader,
 		rand:                rand.Reader,
+		// default is to spin a goroutine to process the given work.
+		AsyncWorkComputation: func(f func()) {
+			go f()
+		},
 	}
 }
 

--- a/tss/params.go
+++ b/tss/params.go
@@ -34,7 +34,7 @@ type (
 
 		// can be used by rounds to perform work asynchronously
 		Context              context.Context
-		AsyncWorkComputation func(func())
+		AsyncWorkComputation func(func()) error // nil value means it'll spin a goroutine for any async task.
 	}
 
 	ReSharingParameters struct {
@@ -61,10 +61,6 @@ func NewParameters(ec elliptic.Curve, ctx *PeerContext, partyID *PartyID, partyC
 		safePrimeGenTimeout: defaultSafePrimeGenTimeout,
 		partialKeyRand:      rand.Reader,
 		rand:                rand.Reader,
-		// default is to spin a goroutine to process the given work.
-		AsyncWorkComputation: func(f func()) {
-			go f()
-		},
 	}
 }
 


### PR DESCRIPTION
Threadpool will recycle goroutines in the ecdsa signing protocol.
Added unit test to validate all goroutines manage to abort "mid-task".
