### PR TITLE
adding trackingId to errors + small fix

### DIFF
--- a/ecdsa/signing/finalize.go
+++ b/ecdsa/signing/finalize.go
@@ -80,7 +80,7 @@ func (round *finalization) Start() *tss.Error {
 		return round.WrapError(fmt.Errorf("signature verification failed"))
 	}
 
-	round.end <- round.data
+	round.sendSignature()
 
 	return nil
 }

--- a/ecdsa/signing/rounds.go
+++ b/ecdsa/signing/rounds.go
@@ -134,10 +134,14 @@ func (round *base) sendMessage(msg tss.ParsedMessage) *tss.Error {
 		return round.WrapError(errors.New("received nil Params"))
 	}
 
+	if round.Params().Context == nil {
+		round.out <- msg
+		return nil
+	}
+
 	select {
 	case round.out <- msg:
 		return nil
-	// if context is nil, select clause will simply ignore it.
 	case <-round.Params().Context.Done():
 		return round.WrapError(errors.New("round aborted"))
 	}
@@ -149,6 +153,11 @@ func (round *base) sendSignature() {
 		return
 	}
 	if round.Params() == nil {
+		return
+	}
+
+	if round.Params().Context == nil {
+		round.end <- round.data
 		return
 	}
 

--- a/ecdsa/signing/rounds.go
+++ b/ecdsa/signing/rounds.go
@@ -137,7 +137,6 @@ func (round *base) sendMessage(msg tss.ParsedMessage) *tss.Error {
 	select {
 	case round.out <- msg:
 		return nil
-
 	// if context is nil, select clause will simply ignore it.
 	case <-round.Params().Context.Done():
 		return round.WrapError(errors.New("round aborted"))
@@ -145,8 +144,17 @@ func (round *base) sendMessage(msg tss.ParsedMessage) *tss.Error {
 }
 
 func (round *base) sendSignature() {
+	// shouldn't ever reach these cases, but it is better to be safe than sorry.
+	if round.out == nil {
+		return
+	}
+	if round.Params() == nil {
+		return
+	}
+
 	select {
 	case round.end <- round.data:
+	// if context is nil, select clause will simply ignore it.
 	case <-round.Params().Context.Done():
 	}
 }

--- a/tss/error.go
+++ b/tss/error.go
@@ -17,10 +17,15 @@ type Error struct {
 	round    int
 	victim   *PartyID
 	culprits []*PartyID
+
+	trackId []byte // optional.
 }
 
 func NewError(err error, task string, round int, victim *PartyID, culprits ...*PartyID) *Error {
 	return &Error{cause: err, task: task, round: round, victim: victim, culprits: culprits}
+}
+func NewTrackableError(err error, task string, round int, victim *PartyID, trackId []byte, culprits ...*PartyID) *Error {
+	return &Error{cause: err, task: task, round: round, victim: victim, culprits: culprits, trackId: trackId}
 }
 
 func (err *Error) Unwrap() error { return err.cause }
@@ -46,3 +51,5 @@ func (err *Error) Error() string {
 	return fmt.Sprintf("task %s, party %v, round %d: %s",
 		err.task, err.victim, err.round, err.cause.Error())
 }
+
+func (err *Error) TrackId() []byte { return err.trackId }

--- a/tss/error.go
+++ b/tss/error.go
@@ -18,14 +18,14 @@ type Error struct {
 	victim   *PartyID
 	culprits []*PartyID
 
-	trackId []byte // optional.
+	trackingId []byte // optional.
 }
 
 func NewError(err error, task string, round int, victim *PartyID, culprits ...*PartyID) *Error {
 	return &Error{cause: err, task: task, round: round, victim: victim, culprits: culprits}
 }
-func NewTrackableError(err error, task string, round int, victim *PartyID, trackId []byte, culprits ...*PartyID) *Error {
-	return &Error{cause: err, task: task, round: round, victim: victim, culprits: culprits, trackId: trackId}
+func NewTrackableError(err error, task string, round int, victim *PartyID, trackingId []byte, culprits ...*PartyID) *Error {
+	return &Error{cause: err, task: task, round: round, victim: victim, culprits: culprits, trackingId: trackingId}
 }
 
 func (err *Error) Unwrap() error { return err.cause }
@@ -52,4 +52,4 @@ func (err *Error) Error() string {
 		err.task, err.victim, err.round, err.cause.Error())
 }
 
-func (err *Error) TrackId() []byte { return err.trackId }
+func (err *Error) TrackingId() []byte { return err.trackingId }


### PR DESCRIPTION
Added trackingId to errors in ecdsa to ensure fulParty output can be logged correctly by users.

In addition, ensured that once the FullParty context is closed, signatures won't wait forever on the signatureOut channel. 