### PR TITLE
ensuring index doesn't cause issues

### DIFF
--- a/ecdsa/party/implementation.go
+++ b/ecdsa/party/implementation.go
@@ -277,6 +277,7 @@ func (signer *singleSigner) consumeBuffer(errReportFunc func(newError *tss.Error
 				if !ok {
 					errReportFunc(err)
 				}
+
 			}
 		}
 
@@ -353,10 +354,6 @@ func (signer *singleSigner) feedLocalParty(msg tss.ParsedMessage) (bool, *tss.Er
 	}
 
 	msg.GetFrom().Index = int(index)
-
-	if !msg.GetFrom().ValidateBasic() {
-		panic("MF")
-	}
 
 	return signer.localParty.Update(msg)
 }


### PR DESCRIPTION
Since users might not know the indices of the subgroup chosen to operate - I've ensured indices won't cause errors:
The FullParty will determine the correct values for an index.